### PR TITLE
add bower support / Issue #1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,30 @@
+{
+  "name": "Arctext.js",
+  "version": "1.0.0",
+  "homepage": "https://github.com/codrops/Arctext",
+  "description": "Arctext.js lets you arrage each letter of a text along a curved path",
+  "main": "js/jquery.arctext.js",
+  "keywords": [
+    "js",
+    "javascript",
+    "jquery",
+    "arctext",
+    "codrops",
+    "bend",
+    "wrap",
+    "curved",
+    "text",
+    "letter"
+  ],
+  "authors": [
+    "https://github.com/botelho"
+  ],
+  "license": "http://tympanus.net/codrops/licensing/",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Added [Bower](http://bower.io/) support
```
bower install arctext-js
```

Will remove bower package with forked repo as soon as this PR was merged, so it can be registered with the original one instead.
```
bower register arctext-js git://github.com/codrops/Arctext
```